### PR TITLE
Core API for signature removal and repeatability.

### DIFF
--- a/OpenVsixSignTool.sln.DotSettings
+++ b/OpenVsixSignTool.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AA_BB" /&gt;</s:String></wpf:ResourceDictionary>

--- a/src/OpenVsixSignTool.Core/OpcPackageSignatureBuilder.cs
+++ b/src/OpenVsixSignTool.Core/OpcPackageSignatureBuilder.cs
@@ -80,7 +80,7 @@ namespace OpenVsixSignTool.Core
             }
 
             _package.Flush();
-            var allParts = new List<OpcPart>(_enqueuedParts);
+            var allParts = new HashSet<OpcPart>(_enqueuedParts);
             allParts.Add(originFile);
             allParts.Add(_package.GetPart(_package.Relationships.DocumentUri));
             allParts.Add(_package.GetPart(originFile.Relationships.DocumentUri));

--- a/src/OpenVsixSignTool.Core/OpcPart.cs
+++ b/src/OpenVsixSignTool.Core/OpcPart.cs
@@ -18,6 +18,7 @@ namespace OpenVsixSignTool.Core
         private readonly OpcPackage _package;
 
         public Uri Uri { get; }
+        internal ZipArchiveEntry Entry => _entry;
 
         internal OpcPart(OpcPackage package, string path, ZipArchiveEntry entry, OpcPackageFileMode mode)
         {
@@ -41,11 +42,11 @@ namespace OpenVsixSignTool.Core
 
         public override bool Equals(object obj)
         {
-            switch (obj)
+            if(obj is OpcPart part)
             {
-                case OpcPart part: return Equals(part);
-                default: return false;
+                return Equals(part);
             }
+            return false;
         }
 
         public OpcRelationships Relationships
@@ -68,6 +69,8 @@ namespace OpenVsixSignTool.Core
                 return _package.ContentTypes.FirstOrDefault(ct => string.Equals(ct.Extension, extension, StringComparison.OrdinalIgnoreCase))?.ContentType ?? OpcKnownMimeTypes.OctetString;
             }
         }
+
+        internal OpcPackage Package => _package;
 
         private string GetRelationshipFilePath()
         {

--- a/src/OpenVsixSignTool.Core/OpcSignature.cs
+++ b/src/OpenVsixSignTool.Core/OpcSignature.cs
@@ -1,4 +1,7 @@
-﻿namespace OpenVsixSignTool.Core
+using System;
+using System.Linq;
+
+namespace OpenVsixSignTool.Core
 {
     /// <summary>
     /// Represents an OPC signature.
@@ -9,21 +12,91 @@
     public sealed class OpcSignature
     {
         private readonly OpcPart _signaturePart;
+        private bool _detached;
 
         internal OpcSignature(OpcPart signaturePart)
         {
+            _detached = false;
             _signaturePart = signaturePart;
         }
 
         /// <summary>
         /// Gets the part in the package for this signatures.
         /// </summary>
-        public OpcPart Part => _signaturePart;
+        public OpcPart Part => _detached ? null : _signaturePart;
 
         /// <summary>
         /// Creates a builder to timestamp the existing signature.
         /// </summary>
         /// <returns>An <see cref="OpcPackageTimestampBuilder"/> that allows building and configuring timestamps.</returns>
-        public OpcPackageTimestampBuilder CreateTimestampBuilder() => new OpcPackageTimestampBuilder(_signaturePart);
+        public OpcPackageTimestampBuilder CreateTimestampBuilder()
+        {
+            if (_detached)
+            {
+                throw new InvalidOperationException("Cannot timestamp a signature that has been removed.");
+            }
+            return new OpcPackageTimestampBuilder(_signaturePart);
+        }
+
+
+        /// <summary>
+        /// Removes the signature from the package.
+        /// </summary>
+        public void Remove()
+        {
+            if (_detached)
+            {
+                return;
+            }
+            _detached = true;
+            var originFileRelationship = _signaturePart.Package.Relationships.FirstOrDefault(r => r.Type.Equals(OpcKnownUris.DigitalSignatureOrigin));
+            if (originFileRelationship == null)
+            {
+                //this shouldn't ever happen. This means we have a signature instance but no metadata connecting it to the package.
+                //all we can do at this point is delete the part.
+                _signaturePart.Package.RemovePart(_signaturePart);
+                return;
+            }
+            var originFile = _signaturePart.Package.GetPart(originFileRelationship.Target);
+            if (originFile == null)
+            {
+                //This shouldn't happen either. The package has a relationship to a non-existing origin file. Clean up the
+                //signature part and the relationship.
+                _signaturePart.Package.RemovePart(_signaturePart);
+                _signaturePart.Package.Relationships.Remove(originFileRelationship);
+                return;
+            }
+            var signatureRelationships = originFile.Relationships.Where(
+                r => r.Target == _signaturePart.Uri &&
+                     r.Type == OpcKnownUris.DigitalSignatureSignature
+                ).ToList();
+            if (signatureRelationships.Count == 0)
+            {
+                //Another case that shouldn't happen. There was an origin file, but no relationship to this signature.
+                //Remove the signature. We don't remove the origin file relationship because there could be other valid
+                //relationships at this point.
+                _signaturePart.Package.RemovePart(_signaturePart);
+                return;
+            }
+            //This is the valid scenario. We need to remove the signature part and the origin relationship to this
+            //signature. If there are no more signatures after this one is removed, then we remove the origin file
+            //and the package relationship to the orign.
+            //Note that it is technically incorrect for the origin file to have more than one reference to this signature
+            //with the same type, but if it did happen, we remove all of them.
+
+            //Remove relationships to this signature.
+            foreach (var signatureRelationship in signatureRelationships)
+            {
+                originFile.Relationships.Remove(signatureRelationship);
+            }
+
+            //If we're empty now, remove the origin file and the package relationship to the origin.
+            if (originFile.Relationships.Count == 0)
+            {
+                _signaturePart.Package.RemovePart(originFile);
+                _signaturePart.Package.Relationships.Remove(originFileRelationship);
+            }
+            _signaturePart.Package.RemovePart(_signaturePart);
+        }
     }
 }

--- a/src/OpenVsixSignTool.Core/OpcSignatureManifest.cs
+++ b/src/OpenVsixSignTool.Core/OpcSignatureManifest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 
 namespace OpenVsixSignTool.Core
 {

--- a/src/OpenVsixSignTool/Properties/launchSettings.json
+++ b/src/OpenVsixSignTool/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "OpenVsixSignTool": {
       "commandName": "Project",
-      "commandLineArgs": "sign --sha1 7213125958254779abbaa5033a12fecdf2c7cdc8 --timestamp http://timestamp.digicert.com -ta sha256 -fd sha256 C:\\Users\\Administrator\\Desktop\\VsVim-vs2015.vsix"
+      "commandLineArgs": "sign --sha1 7213125958254779abbaa5033a12fecdf2c7cdc8 --timestamp http://timestamp.digicert.com -ta sha256 -fd sha256 C:\\Users\\Administrator\\Desktop\\OpenVsixSignToolTest.vsix"
     }
   }
 }


### PR DESCRIPTION
This provides a public API for removing a signature, and fixes the
signing process to correctly overwrite an existing signature.

Fixes #11.