### PR TITLE
Unsign with various fixes.

### DIFF
--- a/src/OpenVsixSignTool.Core/OpcPackage.cs
+++ b/src/OpenVsixSignTool.Core/OpcPackage.cs
@@ -217,6 +217,7 @@ namespace OpenVsixSignTool.Core
                 using (var stream = entry.Open())
                 {
                     var newXml = _contentTypes.ToXml();
+                    stream.SetLength(0L);
                     newXml.Save(stream, SaveOptions.None);
                     _contentTypes.IsDirty = false;
                 }
@@ -233,6 +234,7 @@ namespace OpenVsixSignTool.Core
             var entry = _archive.GetEntry(path) ?? _archive.CreateEntry(path);
             using (var stream = entry.Open())
             {
+                stream.SetLength(0L);
                 var newXml = relationships.ToXml();
                 newXml.Save(stream, SaveOptions.None);
             }
@@ -260,7 +262,8 @@ namespace OpenVsixSignTool.Core
             {
                 yield break;
             }
-            foreach (var signatureRelationship in originPart.Relationships.Where(r => r.Type.Equals(OpcKnownUris.DigitalSignatureSignature)))
+            var signatureRelationships = originPart.Relationships.Where(r => r.Type.Equals(OpcKnownUris.DigitalSignatureSignature)).ToList();
+            foreach (var signatureRelationship in signatureRelationships.ToList())
             {
                 var signaturePart = GetPart(signatureRelationship.Target);
                 if (signaturePart == null)

--- a/src/OpenVsixSignTool.Core/OpcPackageSignatureBuilder.cs
+++ b/src/OpenVsixSignTool.Core/OpcPackageSignatureBuilder.cs
@@ -93,6 +93,7 @@ namespace OpenVsixSignTool.Core
                 var result = builder.Build();
                 using (var copySignatureStream = signatureFile.Open())
                 {
+                    copySignatureStream.SetLength(0L);
                     using (var xmlWriter = new XmlTextWriter(copySignatureStream, System.Text.Encoding.UTF8))
                     {
                         //The .NET implementation of OPC used by Visual Studio does not tollerate "white space" nodes.

--- a/src/OpenVsixSignTool.Core/OpcSignature.cs
+++ b/src/OpenVsixSignTool.Core/OpcSignature.cs
@@ -67,7 +67,7 @@ namespace OpenVsixSignTool.Core
                 return;
             }
             var signatureRelationships = originFile.Relationships.Where(
-                r => r.Target == _signaturePart.Uri &&
+                r => r.Target == _signaturePart.Uri.ToQualifiedUri() &&
                      r.Type == OpcKnownUris.DigitalSignatureSignature
                 ).ToList();
             if (signatureRelationships.Count == 0)

--- a/src/OpenVsixSignTool.Core/UriHelpers.cs
+++ b/src/OpenVsixSignTool.Core/UriHelpers.cs
@@ -21,13 +21,19 @@ namespace OpenVsixSignTool.Core
             return resolved.ToString();
         }
 
-
         public static string ToQualifiedPath(this Uri partUri)
         {
             var absolute = partUri.IsAbsoluteUri ? partUri : new Uri(RootedPackageBaseUri, partUri);
             var pathUri = new Uri(absolute.GetComponents(UriComponents.SchemeAndServer | UriComponents.PathAndQuery, UriFormat.Unescaped), UriKind.Absolute);
             var resolved = RootedPackageBaseUri.MakeRelativeUri(pathUri);
             return resolved.ToString();
+        }
+
+        public static Uri ToQualifiedUri(this Uri partUri)
+        {
+            var absolute = partUri.IsAbsoluteUri ? partUri : new Uri(RootedPackageBaseUri, partUri);
+            var pathUri = new Uri(absolute.GetComponents(UriComponents.SchemeAndServer | UriComponents.PathAndQuery, UriFormat.Unescaped), UriKind.Absolute);
+            return RootedPackageBaseUri.MakeRelativeUri(pathUri);
         }
     }
 }

--- a/src/OpenVsixSignTool.Core/XmlSignatureBuilder.cs
+++ b/src/OpenVsixSignTool.Core/XmlSignatureBuilder.cs
@@ -10,8 +10,8 @@ namespace OpenVsixSignTool.Core
     {
         private readonly XmlDocument _document;
         private readonly SigningContext _signingContext;
+        private readonly XmlElement _signatureElement;
         private XmlElement _objectElement;
-        private XmlElement _signatureElement;
 
 
         /// <summary>

--- a/src/OpenVsixSignTool/Program.cs
+++ b/src/OpenVsixSignTool/Program.cs
@@ -9,22 +9,34 @@ namespace OpenVsixSignTool
         {
             var application = new CommandLineApplication(throwOnUnexpectedArg: false);
             var signCommand = application.Command("sign", throwOnUnexpectedArg: false, configuration: signConfiguration =>
-            {
-                signConfiguration.Description = "Signs a VSIX package.";
-                signConfiguration.HelpOption("-? | -h | --help");
-                var sha1 = signConfiguration.Option("-s | --sha1", "A hex-encoded SHA-1 thumbprint of the certificate used to sign the executable.", CommandOptionType.SingleValue);
-                var pfxPath = signConfiguration.Option("-c | --certificate", "A path to a PFX file to perform the signature.", CommandOptionType.SingleValue);
-                var password = signConfiguration.Option("-p | --password", "The password for the PFX file.", CommandOptionType.SingleValue);
-                var timestamp = signConfiguration.Option("-t | --timestamp", "A URL of the timestamping server to timestamp the signature.", CommandOptionType.SingleValue);
-                var timestampAlgorithm = signConfiguration.Option("-ta | --timestamp-algorithm", "The digest algorithm of the timestamp.", CommandOptionType.SingleValue);
-                var fileDigest = signConfiguration.Option("-fd | --file-digest", "A URL of the timestamping server to timestamp the signature.", CommandOptionType.SingleValue);
-                var force = signConfiguration.Option("-f | --force", "Force the signature by overwriting any existing signatures.", CommandOptionType.NoValue);
-                var file = signConfiguration.Argument("file", "A path to the PFX used to sign the VSIX file.");
-                signConfiguration.OnExecute(() =>
                 {
-                    return new SignCommand(signConfiguration).Sign(sha1, pfxPath, password, timestamp, timestampAlgorithm, fileDigest, force, file);
-                });
-            });
+                    signConfiguration.Description = "Signs a VSIX package.";
+                    signConfiguration.HelpOption("-? | -h | --help");
+                    var sha1 = signConfiguration.Option("-s | --sha1", "A hex-encoded SHA-1 thumbprint of the certificate used to sign the executable.", CommandOptionType.SingleValue);
+                    var pfxPath = signConfiguration.Option("-c | --certificate", "A path to a PFX file to perform the signature.", CommandOptionType.SingleValue);
+                    var password = signConfiguration.Option("-p | --password", "The password for the PFX file.", CommandOptionType.SingleValue);
+                    var timestamp = signConfiguration.Option("-t | --timestamp", "A URL of the timestamping server to timestamp the signature.", CommandOptionType.SingleValue);
+                    var timestampAlgorithm = signConfiguration.Option("-ta | --timestamp-algorithm", "The digest algorithm of the timestamp.", CommandOptionType.SingleValue);
+                    var fileDigest = signConfiguration.Option("-fd | --file-digest", "A URL of the timestamping server to timestamp the signature.", CommandOptionType.SingleValue);
+                    var force = signConfiguration.Option("-f | --force", "Force the signature by overwriting any existing signatures.", CommandOptionType.NoValue);
+                    var file = signConfiguration.Argument("file", "A to the VSIX file.");
+                    signConfiguration.OnExecute(() =>
+                    {
+                        return new SignCommand(signConfiguration).Sign(sha1, pfxPath, password, timestamp, timestampAlgorithm, fileDigest, force, file);
+                    });
+                }
+            );
+            var unsignCommand = application.Command("unsign", throwOnUnexpectedArg: false, configuration: unsignConfiguration =>
+                {
+                    unsignConfiguration.Description = "Removes all signatures from a VSIX package.";
+                    unsignConfiguration.HelpOption("-? | -h | --help");
+                    var file = unsignConfiguration.Argument("file", "A path to the VSIX file.");
+                    unsignConfiguration.OnExecute(() =>
+                    {
+                        return new UnsignCommand(unsignConfiguration).Unsign(file);
+                    });
+                }
+            );
             application.HelpOption("-? | -h | --help");
             application.VersionOption("-v | --version", typeof(Program).Assembly.GetName().Version.ToString(3));
             if (args.Length == 0)

--- a/src/OpenVsixSignTool/Properties/launchSettings.json
+++ b/src/OpenVsixSignTool/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "OpenVsixSignTool": {
       "commandName": "Project",
-      "commandLineArgs": "sign --sha1 7213125958254779abbaa5033a12fecdf2c7cdc8 --timestamp http://timestamp.digicert.com -ta sha256 -fd sha256 C:\\Users\\Administrator\\Desktop\\OpenVsixSignToolTest.vsix"
+      "commandLineArgs": "unsign C:\\Users\\Administrator\\Desktop\\OpenVsixSignToolTest.vsix"
     }
   }
 }

--- a/src/OpenVsixSignTool/UnsignCommand.cs
+++ b/src/OpenVsixSignTool/UnsignCommand.cs
@@ -1,0 +1,48 @@
+﻿using System.IO;
+using Microsoft.Extensions.CommandLineUtils;
+using OpenVsixSignTool.Core;
+
+namespace OpenVsixSignTool
+{
+    internal class UnsignCommand
+    {
+        internal class EXIT_CODES
+        {
+            public const int SUCCESS = 0;
+            public const int INVALID_OPTIONS = 1;
+            public const int FAILED = 2;
+        }
+
+        private readonly CommandLineApplication _unsignConfiguration;
+
+        public UnsignCommand(CommandLineApplication unsignConfiguration)
+        {
+            _unsignConfiguration = unsignConfiguration;
+        }
+
+        public int Unsign(CommandArgument vsixPath)
+        {
+            var vsixPathValue = vsixPath.Value;
+            if (!File.Exists(vsixPathValue))
+            {
+                _unsignConfiguration.Out.WriteLine("Specified file does not exist.");
+                return SignCommand.EXIT_CODES.INVALID_OPTIONS;
+            }
+            using (var package = OpcPackage.Open(vsixPathValue, OpcPackageFileMode.ReadWrite))
+            {
+                var unsigned = false;
+                foreach (var signature in package.GetSignatures())
+                {
+                    unsigned = true;
+                    signature.Remove();
+                }
+                if (!unsigned)
+                {
+                    _unsignConfiguration.Out.WriteLine("Specified VSIX is not signed.");
+                    return EXIT_CODES.FAILED;
+                }
+                return EXIT_CODES.SUCCESS;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds support for unsigning a package.

This also fixes a number of other issues, particularly found when
removing content. The ZIP stream was not truncated before the file
was written, and if the new content was shorter than the old content,
then parts of the old content would not be removed.

This also fixes an issue where the origin relationship may not have
been removed correctly.

Fixes #6.