### PR TITLE
Fix OPC URIs for ECDSA.

### DIFF
--- a/src/OpenVsixSignTool.Core/KeyVaultConfigurationDiscoverer.cs
+++ b/src/OpenVsixSignTool.Core/KeyVaultConfigurationDiscoverer.cs
@@ -18,6 +18,7 @@ namespace OpenVsixSignTool.Core
             {
                 var context = new AuthenticationContext(authority);
                 ClientCredential credential = new ClientCredential(configuration.AzureClientId, configuration.AzureClientSecret);
+
                 AuthenticationResult result = await context.AcquireTokenAsync(resource, credential);
                 if (result == null)
                 {

--- a/src/OpenVsixSignTool.Core/OpcKnownUris.cs
+++ b/src/OpenVsixSignTool.Core/OpcKnownUris.cs
@@ -20,10 +20,10 @@ namespace OpenVsixSignTool.Core
             public static readonly Uri rsaSHA384 = new Uri("http://www.w3.org/2001/04/xmldsig-more#rsa-sha384", UriKind.Absolute);
             public static readonly Uri rsaSHA512 = new Uri("http://www.w3.org/2001/04/xmldsig-more#rsa-sha512", UriKind.Absolute);
 
-            public static readonly Uri ecdsaSHA1 = new Uri("http://www.w3.org/2000/09/xmldsig#ecdsa-sha1", UriKind.Absolute);
-            public static readonly Uri ecdsaSHA256 = new Uri("http://www.w3.org/2000/09/xmldsig#ecdsa-sha256", UriKind.Absolute);
-            public static readonly Uri ecdsaSHA384 = new Uri("http://www.w3.org/2000/09/xmldsig#ecdsa-sha384", UriKind.Absolute);
-            public static readonly Uri ecdsaSHA512 = new Uri("http://www.w3.org/2000/09/xmldsig#ecdsa-sha512", UriKind.Absolute);
+            public static readonly Uri ecdsaSHA1 = new Uri("http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1", UriKind.Absolute);
+            public static readonly Uri ecdsaSHA256 = new Uri("http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256", UriKind.Absolute);
+            public static readonly Uri ecdsaSHA384 = new Uri("http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384", UriKind.Absolute);
+            public static readonly Uri ecdsaSHA512 = new Uri("http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512", UriKind.Absolute);
         }
 
         public static class HashAlgorithms

--- a/tests/OpenVsixSignTool.Core.Tests/OpenVsixSignTool.Core.Tests.csproj
+++ b/tests/OpenVsixSignTool.Core.Tests/OpenVsixSignTool.Core.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
 
     <ProjectReference Include="..\..\src\OpenVsixSignTool.Core\OpenVsixSignTool.Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
The URI identifiers for ECDSA were incorrect. Also only use
Newtonsoft.Json 6.0.8 which is the same version that is used by the
Azure SDK so we don't have to use binding redirects.