### PR TITLE
Provide a solution that does not create digests for origin.psdor files

### DIFF
--- a/src/OpenVsixSignTool.Core/OpcPackage.cs
+++ b/src/OpenVsixSignTool.Core/OpcPackage.cs
@@ -241,6 +241,14 @@ namespace OpenVsixSignTool.Core
         public OpcPackageSignatureBuilder CreateSignatureBuilder() => new OpcPackageSignatureBuilder(this);
 
         /// <summary>
+        /// Creates a signature builder for applying a digital signature to the package, while ignoring 
+        /// origin.psdor files
+        /// </summary>
+        /// <returns>A builder instance for configuring and applying a signature.</returns>
+        public OpcPackageSignatureBuilder CreateSignatureBuilderIgnoreOrigin() => 
+            new OpcPackageSignatureBuilder( this, ignoreOrigin: true );
+
+        /// <summary>
         /// Enumerates over all of the signatures in the package.
         /// </summary>
         /// <returns>An enumerable collection of signatures in the package.</returns>

--- a/src/OpenVsixSignTool.Core/OpcPackageSignatureBuilder.cs
+++ b/src/OpenVsixSignTool.Core/OpcPackageSignatureBuilder.cs
@@ -12,11 +12,20 @@ namespace OpenVsixSignTool.Core
     {
         private readonly OpcPackage _package;
         private readonly List<OpcPart> _enqueuedParts;
+        private readonly bool _ignoreOriginParts;
 
         internal OpcPackageSignatureBuilder(OpcPackage package)
         {
             _enqueuedParts = new List<OpcPart>();
             _package = package;
+            _ignoreOriginParts = false;
+        }
+
+        internal OpcPackageSignatureBuilder( OpcPackage package, bool ignoreOrigin )
+        {
+            _enqueuedParts = new List<OpcPart>();
+            _package = package;
+            _ignoreOriginParts = ignoreOrigin;
         }
 
         /// <summary>
@@ -106,12 +115,25 @@ namespace OpenVsixSignTool.Core
             }
 
             _package.Flush();
-            var allParts = new HashSet<OpcPart>(_enqueuedParts)
+            HashSet<OpcPart> allParts = new HashSet<OpcPart>( _enqueuedParts );
+
+            if ( _ignoreOriginParts )
             {
-                originFile,
-                _package.GetPart(_package.Relationships.DocumentUri),
-                _package.GetPart(originFile.Relationships.DocumentUri)
-            };
+                allParts = new HashSet<OpcPart>( _enqueuedParts )
+                {
+                    _package.GetPart(_package.Relationships.DocumentUri)
+                };
+            }
+            else
+            {
+                allParts = new HashSet<OpcPart>( _enqueuedParts )
+                {
+                    originFile,
+                    _package.GetPart(_package.Relationships.DocumentUri),
+                    _package.GetPart(originFile.Relationships.DocumentUri)
+                };
+            }
+            
             return (allParts, signatureFile);
         }
     }


### PR DESCRIPTION
The solution does provide a mechanism for picking the parts that can be signed (ISignatureBuilderPreset), and a mechanism for removing parts, the Sign will always add origin.psdor and origin.psdor.rels.  

There is a need to ensure that these files are not included in the signature, hence the pull request.

No tests have been provided, as test seems to be quite challenging to create.

This is a minor change, so no issue has been created.
