### PR TITLE
Adds the capability to pass TenantId in 

### DIFF
--- a/OpenVsixSignTool.sln
+++ b/OpenVsixSignTool.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.34909.67
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenVsixSignTool.Core", "src\OpenVsixSignTool.Core\OpenVsixSignTool.Core.csproj", "{351BD833-DE64-4042-9ADE-343825443A36}"
 EndProject
@@ -13,8 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenVsixSignTool.Tests", "t
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{49F130E1-BD5B-43AD-98C6-4CDE1AA10B2A}"
 	ProjectSection(SolutionItems) = preProject
-		azure-pipelines.yml = azure-pipelines.yml
 		Directory.Build.props = Directory.Build.props
+		.github\workflows\pr.yml = .github\workflows\pr.yml
 	EndProjectSection
 EndProject
 Global

--- a/src/OpenVsixSignTool/AzureKeyVaultMaterializedConfiguration.cs
+++ b/src/OpenVsixSignTool/AzureKeyVaultMaterializedConfiguration.cs
@@ -1,19 +1,22 @@
-﻿using Microsoft.Azure.KeyVault;
+﻿using System;
 using System.Security.Cryptography.X509Certificates;
+
+using Azure.Identity;
+using Azure.Security.KeyVault.Keys.Cryptography;
 
 namespace OpenVsixSignTool
 {
     public class AzureKeyVaultMaterializedConfiguration
     {
-        public AzureKeyVaultMaterializedConfiguration(KeyVaultClient client, X509Certificate2 publicCertificate, KeyIdentifier keyId)
+        public AzureKeyVaultMaterializedConfiguration(ClientSecretCredential creds, Uri keyId, X509Certificate2 x509Certificate)
         {
-            Client = client;
-            KeyId = keyId;
-            PublicCertificate = publicCertificate;
+            this.Credentials = creds;
+            this.KeyId = keyId;
+            this.PublicCertificate = x509Certificate;
         }
 
         public X509Certificate2 PublicCertificate { get; }
-        public KeyVaultClient Client { get; }
-        public KeyIdentifier KeyId { get; }
+        public ClientSecretCredential Credentials { get; }
+        public Uri KeyId { get; }
     }
 }

--- a/src/OpenVsixSignTool/AzureKeyVaultSignConfigurationSet.cs
+++ b/src/OpenVsixSignTool/AzureKeyVaultSignConfigurationSet.cs
@@ -8,5 +8,6 @@ namespace OpenVsixSignTool
         public string AzureKeyVaultUrl { get; set; }
         public string AzureKeyVaultCertificateName { get; set; }
         public string AzureAccessToken { get; set; }
+        public string AzureTenantId { get; set; }
     }
 }

--- a/src/OpenVsixSignTool/OpenVsixSignTool.csproj
+++ b/src/OpenVsixSignTool/OpenVsixSignTool.csproj
@@ -16,11 +16,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Cryptography" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
-    <PackageReference Include="RSAKeyVaultProvider" Version="1.1.22" />
+    <PackageReference Include="RSAKeyVaultProvider" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenVsixSignTool.Core\OpenVsixSignTool.Core.csproj" />

--- a/src/OpenVsixSignTool/Program.cs
+++ b/src/OpenVsixSignTool/Program.cs
@@ -21,6 +21,7 @@ namespace OpenVsixSignTool
                     var file = signConfiguration.Argument("file", "A to the VSIX file.");
 
                     var azureKeyVaultUrl = signConfiguration.Option("-kvu | --azure-key-vault-url", "The URL to an Azure Key Vault.", CommandOptionType.SingleValue);
+                    var azureKeyVaultTenantId = signConfiguration.Option("-kvt | --azure-key-vault-tenant-id", "The Tenant ID to authenticate to the Azure Key Vault.", CommandOptionType.SingleValue);
                     var azureKeyVaultClientId = signConfiguration.Option("-kvi | --azure-key-vault-client-id", "The Client ID to authenticate to the Azure Key Vault.", CommandOptionType.SingleValue);
                     var azureKeyVaultClientSecret = signConfiguration.Option("-kvs | --azure-key-vault-client-secret", "The Client Secret to authenticate to the Azure Key Vault.", CommandOptionType.SingleValue);
                     var azureKeyVaultCertificateName = signConfiguration.Option("-kvc | --azure-key-vault-certificate", "The name of the certificate in Azure Key Vault.", CommandOptionType.SingleValue);
@@ -35,7 +36,7 @@ namespace OpenVsixSignTool
                         }
                         else
                         {
-                            return sign.SignAzure(azureKeyVaultUrl, azureKeyVaultClientId, azureKeyVaultClientSecret,
+                            return sign.SignAzure(azureKeyVaultUrl, azureKeyVaultTenantId, azureKeyVaultClientId, azureKeyVaultClientSecret,
                                 azureKeyVaultCertificateName, azureKeyVaultAccessToken, force, fileDigest, timestamp, timestampAlgorithm, file);
                         }
                     });


### PR DESCRIPTION
When using client id & secret, it's also necessary to support Tenant Id.

Changing to this approach meant consuming the new Azure SDKs which support this, and also upgrading the `RSAKeyVault` package to get corresponding support.

adds the `-kvt` paramter to the input set.